### PR TITLE
Add methods for retrieving all possible pronunciations of a character

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rime-cantonese-upstream"]
+	path = rime-cantonese-upstream
+	url = https://github.com/CanCLID/rime-cantonese-upstream

--- a/README.md
+++ b/README.md
@@ -20,18 +20,22 @@ npm install to-jyutping
 
 ```js
 import ToJyutping from "to-jyutping";
-> ToJyutping.getJyutpingList("一瓩係乜嘢嚟㗎？");
-[["一", "jat1"], ["瓩", "cin1 ngaa5"], ["係", "hai6"], ["乜", "mat1"], ["嘢", "je5"], ["嚟", "lai4"], ["㗎", "gaa3"], ["？", null]]
-> ToJyutping.getJyutping("一瓩係乜嘢嚟㗎？");
-"一(jat1)瓩(cin1 ngaa5)係(hai6)乜(mat1)嘢(je5)嚟(lai4)㗎(gaa3)？"
-> ToJyutping.getJyutpingText("一瓩係乜嘢嚟㗎？");
-"jat1 cin1 ngaa5 hai6 mat1 je5 lai4 gaa3"
-> ToJyutping.getIPAList("一瓩係乜嘢嚟㗎？");
-[["一", "jɐt̚˥"], ["瓩", "t͡sʰiːn˥.ŋaː˩˧"], ["係", "hɐi̯˨"], ["乜", "mɐt̚˥"], ["嘢", "jɛː˩˧"], ["嚟", "lɐi̯˨˩"], ["㗎", "kaː˧"], ["？", null]]
-> ToJyutping.getIPA("一瓩係乜嘢嚟㗎？");
-"一[jɐt̚˥]瓩[t͡sʰiːn˥.ŋaː˩˧]係[hɐi̯˨]乜[mɐt̚˥]嘢[jɛː˩˧]嚟[lɐi̯˨˩]㗎[kaː˧]？"
-> ToJyutping.getIPAText("一瓩係乜嘢嚟㗎？");
-"jɐt̚˥.t͡sʰiːn˥.ŋaː˩˧.hɐi̯˨.mɐt̚˥.jɛː˩˧.lɐi̯˨˩.kaː˧"
+> ToJyutping.getJyutpingList("咁啱老世要求佢等陣要開會，剩低嘅嘢我會搞掂㗎喇。");
+[["咁", "gam3"], ["啱", "ngaam1"], ["老", "lou5"], ["世", "sai3"], ["要", "jiu1"], ["求", "kau4"], ["佢", "keoi5"], ["等", "dang2"], ["陣", "zan6"], ["要", "jiu3"], ["開", "hoi1"], ["會", "wui2"], ["，", null], ["剩", "zing6"], ["低", "dai1"], ["嘅", "ge3"], ["嘢", "je5"], ["我", "ngo5"], ["會", "wui5"], ["搞", "gaau2"], ["掂", "dim6"], ["㗎", "gaa3"], ["喇", "laa3"], ["。", null]]
+> ToJyutping.getJyutping("咁啱老世要求佢等陣要開會，剩低嘅嘢我會搞掂㗎喇。");
+"咁(gam3)啱(ngaam1)老(lou5)世(sai3)要(jiu1)求(kau4)佢(keoi5)等(dang2)陣(zan6)要(jiu3)開(hoi1)會(wui2)，剩(zing6)低(dai1)嘅(ge3)嘢(je5)我(ngo5)會(wui5)搞(gaau2)掂(dim6)㗎(gaa3)喇(laa3)。"
+> ToJyutping.getJyutpingText("咁啱老世要求佢等陣要開會，剩低嘅嘢我會搞掂㗎喇。");
+"gam3 ngaam1 lou5 sai3 jiu1 kau4 keoi5 dang2 zan6 jiu3 hoi1 wui2 zing6 dai1 ge3 je5 ngo5 wui5 gaau2 dim6 gaa3 laa3"
+> ToJyutping.getJyutpingCandidates("咁啱老世要求佢等陣要開會，剩低嘅嘢我會搞掂㗎喇。");
+[["咁", ["gam3"]], ["啱", ["ngaam1"]], ["老", ["lou5"]], ["世", ["sai3"]], ["要", ["jiu1", "jiu3", "jiu2"]], ["求", ["kau4"]], ["佢", ["keoi5", "heoi5"]], ["等", ["dang2"]], ["陣", ["zan6"]], ["要", ["jiu3", "jiu2", "jiu1"]], ["開", ["hoi1"]], ["會", ["wui2", "wui5", "wui6", "wui3", "kui2", "kui3"]], ["，", []], ["剩", ["zing6", "sing6"]], ["低", ["dai1"]], ["嘅", ["ge3", "ge2", "koi2", "koi3"]], ["嘢", ["je5"]], ["我", ["ngo5"]], ["會", ["wui5", "wui6", "wui2", "wui3", "kui2", "kui3"]], ["搞", ["gaau2"]], ["掂", ["dim6", "dim3", "dim1"]], ["㗎", ["gaa3", "ga3", "gaa2"]], ["喇", ["laa3", "laa1", "laak3", "laa5", "laat3"]], ["。", []]]
+> ToJyutping.getIPAList("咁啱老世要求佢等陣要開會，剩低嘅嘢我會搞掂㗎喇。");
+[["咁", "kɐm˧"], ["啱", "ŋaːm˥"], ["老", "lou̯˩˧"], ["世", "sɐi̯˧"], ["要", "jiːu̯˥"], ["求", "kʰɐu̯˨˩"], ["佢", "kʰɵy̑˩˧"], ["等", "tɐŋ˧˥"], ["陣", "t͡sɐn˨"], ["要", "jiːu̯˧"], ["開", "hɔːi̯˥"], ["會", "wuːi̯˧˥"], ["，", null], ["剩", "t͡seŋ˨"], ["低", "tɐi̯˥"], ["嘅", "kɛː˧"], ["嘢", "jɛː˩˧"], ["我", "ŋɔː˩˧"], ["會", "wuːi̯˩˧"], ["搞", "kaːu̯˧˥"], ["掂", "tiːm˨"], ["㗎", "kaː˧"], ["喇", "laː˧"], ["。", null]]
+> ToJyutping.getIPA("咁啱老世要求佢等陣要開會，剩低嘅嘢我會搞掂㗎喇。");
+"咁[kɐm˧]啱[ŋaːm˥]老[lou̯˩˧]世[sɐi̯˧]要[jiːu̯˥]求[kʰɐu̯˨˩]佢[kʰɵy̑˩˧]等[tɐŋ˧˥]陣[t͡sɐn˨]要[jiːu̯˧]開[hɔːi̯˥]會[wuːi̯˧˥]，剩[t͡seŋ˨]低[tɐi̯˥]嘅[kɛː˧]嘢[jɛː˩˧]我[ŋɔː˩˧]會[wuːi̯˩˧]搞[kaːu̯˧˥]掂[tiːm˨]㗎[kaː˧]喇[laː˧]。"
+> ToJyutping.getIPAText("咁啱老世要求佢等陣要開會，剩低嘅嘢我會搞掂㗎喇。");
+"kɐm˧.ŋaːm˥.lou̯˩˧.sɐi̯˧.jiːu̯˥.kʰɐu̯˨˩.kʰɵy̑˩˧.tɐŋ˧˥.t͡sɐn˨.jiːu̯˧.hɔːi̯˥.wuːi̯˧˥.t͡seŋ˨.tɐi̯˥.kɛː˧.jɛː˩˧.ŋɔː˩˧.wuːi̯˩˧.kaːu̯˧˥.tiːm˨.kaː˧.laː˧"
+> ToJyutping.getIPACandidates("咁啱老世要求佢等陣要開會，剩低嘅嘢我會搞掂㗎喇。");
+[["咁", ["kɐm˧"]], ["啱", ["ŋaːm˥"]], ["老", ["lou̯˩˧"]], ["世", ["sɐi̯˧"]], ["要", ["jiːu̯˥", "jiːu̯˧", "jiːu̯˧˥"]], ["求", ["kʰɐu̯˨˩"]], ["佢", ["kʰɵy̑˩˧", "hɵy̑˩˧"]], ["等", ["tɐŋ˧˥"]], ["陣", ["t͡sɐn˨"]], ["要", ["jiːu̯˧", "jiːu̯˧˥", "jiːu̯˥"]], ["開", ["hɔːi̯˥"]], ["會", ["wuːi̯˧˥", "wuːi̯˩˧", "wuːi̯˨", "wuːi̯˧", "kʰuːi̯˧˥", "kʰuːi̯˧"]], ["，", []], ["剩", ["t͡seŋ˨", "seŋ˨"]], ["低", ["tɐi̯˥"]], ["嘅", ["kɛː˧", "kɛː˧˥", "kʰɔːi̯˧˥", "kʰɔːi̯˧"]], ["嘢", ["jɛː˩˧"]], ["我", ["ŋɔː˩˧"]], ["會", ["wuːi̯˩˧", "wuːi̯˨", "wuːi̯˧˥", "wuːi̯˧", "kʰuːi̯˧˥", "kʰuːi̯˧"]], ["搞", ["kaːu̯˧˥"]], ["掂", ["tiːm˨", "tiːm˧", "tiːm˥"]], ["㗎", ["kaː˧", "kɐ˧", "kaː˧˥"]], ["喇", ["laː˧", "laː˥", "laːk̚˧", "laː˩˧", "laːt̚˧"]], ["。", []]]
 ```
 
 ### Helper

--- a/Trie.ts
+++ b/Trie.ts
@@ -1,0 +1,49 @@
+type Node = Map<string, Node> & { v?: string[] };
+
+export default class Trie {
+  t: Node = new Map();
+
+  set(k: string, v: string[]) {
+    Array.from(k).reduce((t, c) => {
+      let u = t.get(c);
+      if (!u) t.set(c, (u = new Map()));
+      return u;
+    }, this.t).v = v;
+  }
+
+  serialize() {
+    return (function recursive(t: Node) {
+      let result = "";
+      if (t.v) result += t.v.map(encodeJyutping).join("|");
+      if (t.size > +!t.v) result += "{";
+      t.forEach((v, k) => {
+        result += k + recursive(v);
+      });
+      if (t.size > +!t.v) result += "}";
+      return result;
+    })(this.t);
+  }
+}
+
+const initial = ["", "b", "p", "m", "f", "d", "t", "n", "l", "g", "k", "ng", "gw", "kw", "w", "h", "z", "c", "s", "j"];
+const nucleus = ["aa", "a", "e", "i", "o", "u"];
+const unit = ["oe", "oen", "oeng", "oet", "oek", "eoi", "eon", "eot", "yu", "yun", "yut", "m", "ng"];
+const terminal = ["", "i", "u", "m", "n", "ng", "p", "t", "k"];
+
+const regex = /^([gk]w?|ng|[bpmfdtnlhwzcsj]?)(?![1-6]$)(aa?|oe?|eo?|y?u|i?)(ng|[iumnptk]?)([1-6])$/;
+
+function encodeJyutping(s: string) {
+  return s
+    .split(/\W+/)
+    .map(t => {
+      const [, lead, vowel, final, number] = regex.exec(t) || [];
+      const group = unit.indexOf(vowel + final);
+      const order =
+        +number -
+        1 +
+        (group !== -1 ? group + 54 : terminal.indexOf(final) + nucleus.indexOf(vowel) * 9) * 6 +
+        initial.indexOf(lead) * 402;
+      return String.fromCharCode(order / 90 + 33, (order % 90) + 33);
+    })
+    .join("");
+}

--- a/preprocess.ts
+++ b/preprocess.ts
@@ -1,41 +1,96 @@
-import { spawnSync } from "child_process";
-import { readFileSync, writeFileSync } from "fs";
+import { createReadStream, createWriteStream } from "fs";
+import { createInterface } from "readline";
+import { readdir } from "fs/promises";
+import { resolve } from "path";
 import { OpenCC } from "opencc";
-import Trie from "./src/Trie";
+import { pipeline } from "stream/promises";
+import Trie from "./Trie";
 
-spawnSync("curl -o dict/char.csv https://raw.githubusercontent.com/CanCLID/rime-cantonese-upstream/main/char.csv");
-spawnSync("curl -o dict/word.csv https://raw.githubusercontent.com/CanCLID/rime-cantonese-upstream/main/word.csv");
+(async () => {
+  const rankDict: Record<string, number> = {
+    預設: 0,
+    常用: 1,
+    罕見: 2,
+    棄用: 3,
+  };
 
-const data = new Map<string, [string, number]>();
-for (const path of ["./dict/char.csv", "./dict/word.csv"]) {
-  for (const line of readFileSync(path, { encoding: "utf-8" }).split("\n").slice(1, -1)) {
-    const [字, 粵拼, freq] = line.split(",");
-    if (/[ -~]/.test(字)) continue;
-    const 詞頻 = freq ? (freq.slice(-1) === "%" ? +freq.slice(0, -1) * 0.01 : +freq) : 0.07;
-    if (isNaN(詞頻)) continue;
-    const length = Array.from(字).length;
-    if (length !== 粵拼.split(" ").length && length !== 1) continue;
-    const 元字 = data.get(字);
-    if (元字) {
-      const [元粵拼, 元詞頻] = 元字;
-      if (!(詞頻 > 元詞頻 || (詞頻 === 元詞頻 && 元粵拼.slice(-1) !== "2" && 粵拼.slice(-1) === "2"))) continue;
-    }
-    data.set(字, [粵拼, 詞頻]);
+  const data = new Map<string, Map<string, number>>();
+
+  const rl = createInterface({
+    input: createReadStream("./rime-cantonese-upstream/char.csv"),
+    crlfDelay: Infinity,
+  })[Symbol.asyncIterator]();
+  await rl.next();
+
+  for await (const line of rl) {
+    const [char, jyutping, pronRank] = line.split(",");
+    if (/[ -~]/.test(char)) continue;
+    const freq = rankDict[pronRank];
+    const map = data.get(char);
+    if (map) {
+      const originalFreq = map.get(jyutping) ?? -1;
+      if (freq > originalFreq) map.set(jyutping, freq);
+    } else data.set(char, new Map([[jyutping, freq]]));
   }
-}
 
-const map = new Map<string, string>();
-const converter = new OpenCC("t2s.json");
-data.forEach(([粵拼], 字) => {
-  map.set(字, 粵拼);
-  map.set(converter.convertSync(字), 粵拼);
-});
+  for (const path of await readdir("./rime-cantonese-upstream")) {
+    if (path === "char.csv" || !path.endsWith(".csv")) continue;
+    const rl = createInterface({
+      input: createReadStream(resolve("./rime-cantonese-upstream", path)),
+      crlfDelay: Infinity,
+    })[Symbol.asyncIterator]();
+    const columns = (await rl.next()).value.split(",");
+    const charColumn = columns.indexOf("char");
+    const jyutpingColumn = columns.indexOf("jyutping");
+    if (charColumn === -1 || jyutpingColumn === -1) continue;
 
-let result = "";
-const trie = new Trie();
-map.forEach((粵拼, 字) => {
-  result += 字 + "\t" + 粵拼 + "\n";
-  trie.set(字, 粵拼);
-});
-writeFileSync("./dict/dictionary.txt", result);
-writeFileSync("./dict/trie.txt", trie.serialize());
+    for await (const line of rl) {
+      const values = line.split(",");
+      const char = values[charColumn];
+      if (/[ -~]/.test(char)) continue;
+      const jyutping = values[jyutpingColumn];
+      if (Array.from(char).length !== jyutping.split(" ").length) continue;
+      const map = data.get(char);
+      if (map) {
+        if (!map.has(jyutping)) map.set(jyutping, 4);
+      } else data.set(char, new Map([[jyutping, 4]]));
+    }
+  }
+
+  const dict = new Map(
+    Array.from(data, ([char, map]) => {
+      const freqToJyutping: string[][] = [];
+      for (const [jyutping, freq] of map) {
+        if (!(freq in freqToJyutping)) freqToJyutping[freq] = [jyutping];
+        else freqToJyutping[freq].push(jyutping);
+      }
+      return [
+        char,
+        freqToJyutping.flatMap(rank =>
+          rank
+            .map(jyutping => [
+              jyutping,
+              jyutping
+                .split(" ")
+                .map(u => " 213546"[+u[u.length - 1]] || "_")
+                .join(""),
+            ])
+            .sort(([, left], [, right]) => +(left > right) || -(left < right))
+            .map(([jyutping]) => jyutping)
+        ),
+      ];
+    })
+  );
+
+  const converter = new OpenCC("t2s.json");
+  await Promise.all(
+    Array.from(dict, ([char, map]) => converter.convertPromise(char).then(result => dict.set(result, map)))
+  );
+  await pipeline(
+    Array.from(dict, ([char, jyutpings]) => char + "\t" + jyutpings.join("\t") + "\n"),
+    createWriteStream("./dict/dictionary.txt")
+  );
+  const trie = new Trie();
+  for (const line of dict) trie.set(...line);
+  await new Promise(resolve => createWriteStream(`dict/trie.txt`).write(trie.serialize(), resolve));
+})();

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,10 @@ export function getJyutpingText(s: string) {
     .join(" ");
 }
 
+export function getJyutpingCandidates(s: string) {
+  return t.getAll(s);
+}
+
 export function getIPAList(s: string) {
   return t.get(s).map(a => ((a[1] &&= jyutpingToIPA(a[1])), a));
 }
@@ -39,6 +43,10 @@ export function getIPAText(s: string) {
     .map(([, v]) => v && jyutpingToIPA(v))
     .filter(v => v)
     .join(".");
+}
+
+export function getIPACandidates(s: string) {
+  return t.getAll(s).map(a => ((a[1] = a[1].map(jyutpingToIPA)), a));
 }
 
 type StringRecord = Record<string, string>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES6",
     "lib": ["ESNext"],
     "strict": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
+    "moduleResolution": "nodenext",
     "outDir": "./dist"
-  },
-  "include": ["./src"],
-  "ts-node": {
-    "compilerOptions": {
-      "target": "es6"
-    }
   }
 }


### PR DESCRIPTION
This PR adds two methods `getJyutpingCandidates` and `getIPACandidates`, which return all the possible candidate pronunciations for each character, sorted by the likelihood of that pronunciation being the correct one.

It should only be merged to the `main` branch after PR #2 is merged.